### PR TITLE
Cast to int32 so that negative values work

### DIFF
--- a/src/MKRTHERM.cpp
+++ b/src/MKRTHERM.cpp
@@ -94,7 +94,7 @@ float THERMClass::readTemperature()
     rawword >>= 18;
   }
   // multiply for the LSB value
-  celsius = rawword * 0.25f;
+  celsius = (int32_t)rawword * 0.25f;
 
   return celsius;
 }


### PR DESCRIPTION
The raw value is stored as an unsigned integer, so when multiplied by a float, values that should be negative come out around 1 billion degrees.  This PR simply adds a typecast to fix this.